### PR TITLE
Update User-Agent header

### DIFF
--- a/src/Pecee/Http/Service/Happn.php
+++ b/src/Pecee/Http/Service/Happn.php
@@ -48,8 +48,7 @@ class Happn extends RestBase {
         $this->httpRequest->setHeaders(array(
             'Authorization: OAuth="' . $this->authToken . '"',
             'Content-Type: application/x-www-form-urlencoded',
-            'http.useragent: Happn/1.0 AndroidSDK/0',
-            'User-Agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; SCH-I535 Build/KOT49H)',
+            'User-Agent: Happn/19.1.0 AndroidSDK/19',
             'Host: api.happn.fr',
             'platform: android',
             'connection: Keep-Alive'


### PR DESCRIPTION
Latest Happn release is 19.1.0 on Android.
Needed to avoid HTTP 403 (problem reported by SpringJools in issue #1).
